### PR TITLE
Add support for React Native (close #5)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -148,6 +148,11 @@ export type WebkitMessageHandler = {
   }) => void;
 };
 
+/** Interface for communicating with the React Native tracker */
+export type ReactNativeInterface = {
+  postMessage: (message: string) => void;
+};
+
 declare global {
   interface Window {
     SnowplowWebInterface?: SnowplowWebInterface;
@@ -156,5 +161,6 @@ declare global {
         snowplow?: WebkitMessageHandler;
       };
     };
+    ReactNativeWebView?: ReactNativeInterface;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   WebkitMessageHandler,
   ScreenView,
   SelfDescribingJson,
+  ReactNativeInterface,
 } from './api';
 
 function withAndroidInterface(callback: (_: SnowplowWebInterface) => void) {
@@ -33,6 +34,12 @@ function withIOSInterface(callback: (_: WebkitMessageHandler) => void) {
     window.webkit.messageHandlers.snowplow
   ) {
     callback(window.webkit.messageHandlers.snowplow);
+  }
+}
+
+function withReactNativeInterface(callback: (_: ReactNativeInterface) => void) {
+  if (window.ReactNativeWebView) {
+    callback(window.ReactNativeWebView);
   }
 }
 
@@ -65,13 +72,21 @@ export function trackSelfDescribingEvent(
     );
   });
 
-  withIOSInterface((messageHandler) => {
-    messageHandler.postMessage({
+  const getMessage = () => {
+    return {
       command: 'trackSelfDescribingEvent',
       event: event.event,
       context: event.context,
       trackers: trackers,
-    });
+    };
+  };
+
+  withIOSInterface((messageHandler) => {
+    messageHandler.postMessage(getMessage());
+  });
+
+  withReactNativeInterface((rnInterface) => {
+    rnInterface.postMessage(JSON.stringify(getMessage()));
   });
 }
 
@@ -100,8 +115,8 @@ export function trackStructEvent(
     );
   });
 
-  withIOSInterface((messageHandler) => {
-    messageHandler.postMessage({
+  const getMessage = () => {
+    return {
       command: 'trackStructEvent',
       event: {
         category: event.category,
@@ -112,7 +127,15 @@ export function trackStructEvent(
       },
       context: event.context,
       trackers: trackers,
-    });
+    };
+  };
+
+  withIOSInterface((messageHandler) => {
+    messageHandler.postMessage(getMessage());
+  });
+
+  withReactNativeInterface((rnInterface) => {
+    rnInterface.postMessage(JSON.stringify(getMessage()));
   });
 }
 
@@ -140,8 +163,8 @@ export function trackPageView(
     );
   });
 
-  withIOSInterface((messageHandler) => {
-    messageHandler.postMessage({
+  const getMessage = () => {
+    return {
       command: 'trackPageView',
       event: {
         url: url,
@@ -150,7 +173,15 @@ export function trackPageView(
       },
       context: event?.context,
       trackers: trackers,
-    });
+    };
+  };
+
+  withIOSInterface((messageHandler) => {
+    messageHandler.postMessage(getMessage());
+  });
+
+  withReactNativeInterface((rnInterface) => {
+    rnInterface.postMessage(JSON.stringify(getMessage()));
   });
 }
 
@@ -178,8 +209,8 @@ export function trackScreenView(
     );
   });
 
-  withIOSInterface((messageHandler) => {
-    messageHandler.postMessage({
+  const getMessage = () => {
+    return {
       command: 'trackScreenView',
       event: {
         name: event.name,
@@ -192,6 +223,14 @@ export function trackScreenView(
       },
       context: event.context,
       trackers: trackers,
-    });
+    };
+  };
+
+  withIOSInterface((messageHandler) => {
+    messageHandler.postMessage(getMessage());
+  });
+
+  withReactNativeInterface((rnInterface) => {
+    rnInterface.postMessage(JSON.stringify(getMessage()));
   });
 }

--- a/test/reactNative.test.ts
+++ b/test/reactNative.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import {
+  trackPageView,
+  trackScreenView,
+  trackSelfDescribingEvent,
+  trackStructEvent,
+} from '../src';
+
+describe('React Native interface', () => {
+  let windowSpy: any;
+  let messageHandler = jest.fn();
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+    windowSpy.mockImplementation(() => ({
+      location: { href: 'http://test.com' },
+      ReactNativeWebView: {
+        postMessage: messageHandler,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('track a structured view', () => {
+    trackStructEvent({ category: 'cat', action: 'act' }, ['ns1', 'ns2']);
+    expect(messageHandler).toHaveBeenCalledWith(
+      JSON.stringify({
+        command: 'trackStructEvent',
+        event: {
+          category: 'cat',
+          action: 'act',
+          label: undefined,
+          property: undefined,
+          value: undefined,
+        },
+        context: undefined,
+        trackers: ['ns1', 'ns2'],
+      })
+    );
+  });
+
+  it('tracks a screen view', () => {
+    trackScreenView({ name: 'sv', id: 'xxx' });
+
+    expect(messageHandler).toHaveBeenCalledWith(
+      JSON.stringify({
+        command: 'trackScreenView',
+        event: {
+          name: 'sv',
+          id: 'xxx',
+          type: undefined,
+          previousName: undefined,
+          previousId: undefined,
+          previousType: undefined,
+          transitionType: undefined,
+        },
+        context: undefined,
+        trackers: undefined,
+      })
+    );
+  });
+
+  it('tracks a self-describing event', () => {
+    trackSelfDescribingEvent({
+      event: {
+        schema: 'schema',
+        data: {
+          abc: 1,
+        },
+      },
+    });
+
+    expect(messageHandler).toHaveBeenCalledWith(
+      JSON.stringify({
+        command: 'trackSelfDescribingEvent',
+        event: {
+          schema: 'schema',
+          data: {
+            abc: 1,
+          },
+        },
+        context: undefined,
+        trackers: undefined,
+      })
+    );
+  });
+
+  it('tracks a page view', () => {
+    Object.defineProperty(global.document, 'title', { value: 'Title' });
+    Object.defineProperty(global.document, 'referrer', {
+      value: 'http://referrer.com',
+    });
+
+    trackPageView();
+
+    expect(messageHandler).toHaveBeenCalledWith(
+      JSON.stringify({
+        command: 'trackPageView',
+        event: {
+          url: 'http://test.com',
+          title: 'Title',
+          referrer: 'http://referrer.com',
+        },
+        context: undefined,
+        trackers: undefined,
+      })
+    );
+  });
+
+  it('adds context entities', () => {
+    trackStructEvent(
+      {
+        category: 'cat',
+        action: 'act',
+        context: [
+          {
+            schema: 'schema',
+            data: {
+              abc: 1,
+            },
+          },
+        ],
+      },
+      undefined
+    );
+
+    expect(messageHandler).toHaveBeenCalledWith(
+      JSON.stringify({
+        command: 'trackStructEvent',
+        event: {
+          category: 'cat',
+          action: 'act',
+          label: undefined,
+          property: undefined,
+          value: undefined,
+        },
+        context: [
+          {
+            schema: 'schema',
+            data: {
+              abc: 1,
+            },
+          },
+        ],
+        trackers: undefined,
+      })
+    );
+  });
+});


### PR DESCRIPTION
Issue #5 

Adds support for tracking events in the React Native tracker by implementing the `ReactNativeInterface` interface that is recognized by the [react-native-webview](https://github.com/react-native-webview/react-native-webview) library. Support for receiving messages from the WebView tracker in React Native tracker will be added in version 1.3.0.