### PR TITLE
Send null values instead of undefined to Android backend (close #12)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -102,35 +102,35 @@ export type SnowplowWebInterface = {
   trackSelfDescribingEvent: (
     schema: string,
     data: string,
-    context?: string,
-    trackers?: Array<string>
+    context: string | null,
+    trackers: Array<string> | null
   ) => void;
   trackStructEvent: (
     category: string,
     action: string,
-    label?: string,
-    property?: string,
-    value?: number,
-    context?: string,
-    trackers?: Array<string>
+    label: string | null,
+    property: string | null,
+    value: number | null,
+    context: string | null,
+    trackers: Array<string> | null
   ) => void;
   trackScreenView: (
     name: string,
     id: string,
-    type?: string,
-    previousName?: string,
-    previousId?: string,
-    previousType?: string,
-    transitionType?: string,
-    context?: string,
-    trackers?: Array<string>
+    type: string | null,
+    previousName: string | null,
+    previousId: string | null,
+    previousType: string | null,
+    transitionType: string | null,
+    context: string | null,
+    trackers: Array<string> | null
   ) => void;
   trackPageView: (
     pageUrl: string,
-    pageTitle?: string,
-    referrer?: string,
-    context?: string,
-    trackers?: Array<string>
+    pageTitle: string | null,
+    referrer: string | null,
+    context: string | null,
+    trackers: Array<string> | null
   ) => void;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ function serializeContext(context?: Array<SelfDescribingJson> | null) {
   if (context) {
     return JSON.stringify(context);
   } else {
-    return undefined;
+    return null;
   }
 }
 
@@ -68,7 +68,7 @@ export function trackSelfDescribingEvent(
       event.event.schema,
       JSON.stringify(event.event.data),
       serializeContext(event.context),
-      trackers
+      trackers || null
     );
   });
 
@@ -107,11 +107,11 @@ export function trackStructEvent(
     webInterface.trackStructEvent(
       event.category,
       event.action,
-      event.label,
-      event.property,
-      event.value,
+      event.label || null,
+      event.property || null,
+      event.value || null,
       serializeContext(event.context),
-      trackers
+      trackers || null
     );
   });
 
@@ -159,7 +159,7 @@ export function trackPageView(
       title,
       referrer,
       serializeContext(event?.context),
-      trackers
+      trackers || null
     );
   });
 
@@ -199,13 +199,13 @@ export function trackScreenView(
     webInterface.trackScreenView(
       event.name,
       event.id,
-      event.type,
-      event.previousName,
-      event.previousId,
-      event.previousType,
-      event.transitionType,
+      event.type || null,
+      event.previousName || null,
+      event.previousId || null,
+      event.previousType || null,
+      event.transitionType || null,
       serializeContext(event.context),
-      trackers
+      trackers || null
     );
   });
 

--- a/test/android.test.ts
+++ b/test/android.test.ts
@@ -45,10 +45,10 @@ describe('Android interface', () => {
     expect(trackStructEventStub).toHaveBeenCalledWith(
       'cat',
       'act',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+      null,
+      null,
+      null,
+      null,
       ['ns1', 'ns2']
     );
   });
@@ -58,13 +58,13 @@ describe('Android interface', () => {
     expect(trackScreenViewStub).toHaveBeenCalledWith(
       'sv',
       'xxx',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
     );
   });
 
@@ -81,8 +81,8 @@ describe('Android interface', () => {
     expect(trackSelfDescribingStub).toHaveBeenCalledWith(
       'schema',
       '{"abc":1}',
-      undefined,
-      undefined
+      null,
+      null
     );
   });
 
@@ -97,8 +97,8 @@ describe('Android interface', () => {
       'http://test.com',
       'Title',
       'http://referrer.com',
-      undefined,
-      undefined
+      null,
+      null
     );
   });
 
@@ -122,11 +122,11 @@ describe('Android interface', () => {
     expect(trackStructEventStub).toHaveBeenCalledWith(
       'cat',
       'act',
-      undefined,
-      undefined,
-      undefined,
+      null,
+      null,
+      null,
       '[{"schema":"schema","data":{"abc":1}}]',
-      undefined
+      null
     );
   });
 });

--- a/test/tag.test.ts
+++ b/test/tag.test.ts
@@ -48,17 +48,17 @@ describe('Tag interface', () => {
     expect(trackStructEventStub).toHaveBeenCalledWith(
       'cat',
       'act',
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+      null,
+      null,
+      null,
+      null,
       ['ns1', 'ns2']
     );
     expect(trackSelfDescribingStub).toHaveBeenCalledWith(
       'schema',
       '{"abc":1}',
-      undefined,
-      undefined
+      null,
+      null
     );
 
     windowSpy.mockRestore();


### PR DESCRIPTION
Issue #12 

Fixes running on Android by passing null values instead of undefined to the Android backend. `undefined` were translated into string which caused events not to be tracked.